### PR TITLE
DEEP-9203: Add a new build command to generate a javadb with dependencies

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -5,7 +5,7 @@ on:
     - cron: "0 0 * * *" # update indexes every day in 00:00
 env:
   GH_USER: aqua-bot
-  DB_VERSION: 2   # update version in case of db schema changes. Make sure you don't override the artifact being used in prod
+  DB_VERSION: 3   # update version in case of db schema changes. Make sure you don't override the artifact being used in prod
   packages: write # for GHCR
   contents: read
 jobs:
@@ -37,6 +37,15 @@ jobs:
       - name: Move DB
         run: mv cache/db/javadb.tar.gz .
 
+      - name: Build dependency database
+        run: make dep-db-build
+
+      - name: Compress dependency database
+        run: make dep-db-compress
+
+      - name: Move Dependency DB
+        run: mv cache/dep-db/java-dependencydb.tar.gz .
+
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v1
         with:
@@ -50,3 +59,4 @@ jobs:
           oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json \
           ghcr.io/${{ github.repository }}:${DB_VERSION} \
           javadb.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip
+

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,6 +1,7 @@
 ---
 name: Trivy Java DB
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *" # update indexes every day in 00:00
 env:
@@ -37,15 +38,6 @@ jobs:
       - name: Move DB
         run: mv cache/db/javadb.tar.gz .
 
-      - name: Build dependency database
-        run: make dep-db-build
-
-      - name: Compress dependency database
-        run: make dep-db-compress
-
-      - name: Move Dependency DB
-        run: mv cache/dep-db/java-dependencydb.tar.gz .
-
       - name: Login to GitHub Packages Container registry
         uses: docker/login-action@v1
         with:
@@ -59,4 +51,24 @@ jobs:
           oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json \
           ghcr.io/${{ github.repository }}:${DB_VERSION} \
           javadb.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip
+
+      - name: clean javadb
+        run: |
+          rm -rf cache/db/trivy-java.db cache/db/metadata.json javadb.tar.gz
+
+      - name: Build dependency database
+        run: make dep-db-build
+
+      - name: Compress dependency database
+        run: make dep-db-compress
+
+      - name: Move Dependency DB
+        run: mv cache/dep-db/javadependencydb.tar.gz .
+
+      - name: Upload assets to GHCR
+        run: |
+          oras version
+          oras push --artifact-type application/vnd.aquasec.trivy.config.v1+json \
+          ghcr.io/deepfactor-io/javadependencydb:${DB_VERSION} \
+          javadependencydb.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ dep-db-build: trivy-java-db
 
 .PHONY: dep-db-compress
 dep-db-compress: cache/*
-	tar cvzf cache/dep-db/java-dependencydb.tar.gz -C cache/dep-db/ df-java-dependencies.db metadata.json
+	tar cvzf cache/dep-db/javadependencydb.tar.gz -C cache/dep-db/ df-java-dependency.db metadata.json
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,14 @@ db-build: trivy-java-db
 db-compress: cache/*
 	tar cvzf cache/db/javadb.tar.gz -C cache/db/ trivy-java.db metadata.json
 
+.PHONY: dep-db-build
+dep-db-build: trivy-java-db
+	./trivy-java-db --cache-dir ./cache dependency-build
+
+.PHONY: dep-db-compress
+dep-db-compress: cache/*
+	tar cvzf cache/dep-db/java-dependencydb.tar.gz -C cache/dep-db/ df-java-dependencies.db metadata.json
+
 .PHONY: clean
 clean:
 	rm -rf cache/

--- a/cmd/trivy-java-db/main.go
+++ b/cmd/trivy-java-db/main.go
@@ -45,6 +45,13 @@ var (
 			return build()
 		},
 	}
+	dependencyBuildCmd = &cobra.Command{
+		Use:   "dependency-build",
+		Short: "Build Java DB with dependencies",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return buildWithJarDependencies()
+		},
+	}
 )
 
 func init() {
@@ -59,6 +66,7 @@ func init() {
 
 	rootCmd.AddCommand(crawlCmd)
 	rootCmd.AddCommand(buildCmd)
+	rootCmd.AddCommand(dependencyBuildCmd)
 }
 
 func crawl(ctx context.Context) error {
@@ -88,6 +96,27 @@ func build() error {
 	meta := db.NewMetadata(dbDir)
 	b := builder.NewBuilder(dbc, meta)
 	if err = b.Build(cacheDir); err != nil {
+		return xerrors.Errorf("db build error: %w", err)
+	}
+	return nil
+}
+
+func buildWithJarDependencies() error {
+	if err := db.Reset(cacheDir); err != nil {
+		return xerrors.Errorf("db reset error: %w", err)
+	}
+	dbDir := filepath.Join(cacheDir, "dep-db")
+	log.Printf("Database path: %s", dbDir)
+	dbc, err := db.NewDbWithDependencies(dbDir)
+	if err != nil {
+		return xerrors.Errorf("db create error: %w", err)
+	}
+	if err = dbc.InitDbWithJarDependencies(); err != nil {
+		return xerrors.Errorf("db init error: %w", err)
+	}
+	meta := db.NewMetadata(dbDir)
+	b := builder.NewBuilder(dbc, meta)
+	if err = b.BuildWithDependency(cacheDir); err != nil {
 		return xerrors.Errorf("db build error: %w", err)
 	}
 	return nil

--- a/cmd/trivy-java-db/main.go
+++ b/cmd/trivy-java-db/main.go
@@ -49,7 +49,7 @@ var (
 		Use:   "dependency-build",
 		Short: "Build Java DB with dependencies",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return buildWithJarDependencies()
+			return buildWithDependency()
 		},
 	}
 )
@@ -101,17 +101,17 @@ func build() error {
 	return nil
 }
 
-func buildWithJarDependencies() error {
+func buildWithDependency() error {
 	if err := db.Reset(cacheDir); err != nil {
 		return xerrors.Errorf("db reset error: %w", err)
 	}
 	dbDir := filepath.Join(cacheDir, "dep-db")
 	log.Printf("Database path: %s", dbDir)
-	dbc, err := db.NewDbWithDependencies(dbDir)
+	dbc, err := db.NewDbWithDependency(dbDir)
 	if err != nil {
 		return xerrors.Errorf("db create error: %w", err)
 	}
-	if err = dbc.InitDbWithJarDependencies(); err != nil {
+	if err = dbc.InitDbWithDependency(); err != nil {
 		return xerrors.Errorf("db init error: %w", err)
 	}
 	meta := db.NewMetadata(dbDir)

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -2,7 +2,6 @@ package builder
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"log"
 	"os"
@@ -141,18 +140,13 @@ func (b *Builder) BuildWithDependency(cacheDir string) error {
 			return xerrors.Errorf("failed to decode index: %w", err)
 		}
 		for _, ver := range index.Versions {
-			depList := make([]string, 0)
-			for _, v := range ver.Dependencies {
-				depList = append(depList, fmt.Sprintf("%s:%s:%s", v.GroupID, v.ArtifactID, v.Version))
-			}
-
 			indexes = append(indexes, types.Index{
 				GroupID:     index.GroupID,
 				ArtifactID:  index.ArtifactID,
 				Version:     ver.Version,
 				SHA1:        ver.SHA1,
 				ArchiveType: index.ArchiveType,
-				Dependency:  strings.Join(depList, ","),
+				Dependency:  ver.Dependency,
 			})
 		}
 		bar.Increment()

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -128,12 +128,10 @@ func (b *Builder) BuildWithDependency(cacheDir string) error {
 		}
 		for _, ver := range index.Versions {
 			indexes = append(indexes, types.Index{
-				GroupID:     index.GroupID,
-				ArtifactID:  index.ArtifactID,
-				Version:     ver.Version,
-				SHA1:        ver.SHA1,
-				ArchiveType: index.ArchiveType,
-				Dependency:  ver.Dependency,
+				GroupID:    index.GroupID,
+				ArtifactID: index.ArtifactID,
+				Version:    ver.Version,
+				Dependency: ver.Dependency,
 			})
 		}
 		bar.Increment()
@@ -155,7 +153,7 @@ func (b *Builder) BuildWithDependency(cacheDir string) error {
 	}
 
 	if err := b.db.VacuumDB(); err != nil {
-		return xerrors.Errorf("fauled to vacuum db: %w", err)
+		return xerrors.Errorf("failed to vacuum db: %w", err)
 	}
 
 	// save metadata

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -152,7 +152,7 @@ func (b *Builder) BuildWithDependency(cacheDir string) error {
 		bar.Increment()
 
 		if len(indexes) > 1000 {
-			if err = b.db.InsertIndexesWithJarDependencies(indexes); err != nil {
+			if err = b.db.InsertIndexesWithDependency(indexes); err != nil {
 				return xerrors.Errorf("failed to insert index to db: %w", err)
 			}
 			indexes = []types.Index{}
@@ -163,7 +163,7 @@ func (b *Builder) BuildWithDependency(cacheDir string) error {
 	}
 
 	// Insert the remaining indexes
-	if err = b.db.InsertIndexesWithJarDependencies(indexes); err != nil {
+	if err = b.db.InsertIndexesWithDependency(indexes); err != nil {
 		return xerrors.Errorf("failed to insert index to db: %w", err)
 	}
 

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -112,19 +112,6 @@ func (b *Builder) Build(cacheDir string) error {
 
 func (b *Builder) BuildWithDependency(cacheDir string) error {
 	indexDir := filepath.Join(cacheDir, types.IndexesDir)
-	licenseDir := filepath.Join(cacheDir, types.LicenseDir)
-
-	licenseFile, err := os.Open(licenseDir + types.NormalizedlicenseFileName)
-	if err != nil {
-		xerrors.Errorf("failed to open normalized license file: %w", err)
-	}
-
-	licenseMap := make(map[string]string)
-
-	if err := json.NewDecoder(licenseFile).Decode(&licenseMap); err != nil {
-		return xerrors.Errorf("failed to decode license file: %w", err)
-	}
-
 	count, err := fileutil.Count(indexDir)
 	if err != nil {
 		return xerrors.Errorf("count error: %w", err)

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -90,6 +91,85 @@ func (b *Builder) Build(cacheDir string) error {
 
 	// Insert the remaining indexes
 	if err = b.db.InsertIndexes(indexes); err != nil {
+		return xerrors.Errorf("failed to insert index to db: %w", err)
+	}
+
+	if err := b.db.VacuumDB(); err != nil {
+		return xerrors.Errorf("fauled to vacuum db: %w", err)
+	}
+
+	// save metadata
+	metaDB := db.Metadata{
+		Version:    db.SchemaVersion,
+		NextUpdate: b.clock.Now().UTC().Add(updateInterval),
+		UpdatedAt:  b.clock.Now().UTC(),
+	}
+	if err := b.meta.Update(metaDB); err != nil {
+		return xerrors.Errorf("failed to update metadata: %w", err)
+	}
+
+	return nil
+}
+
+func (b *Builder) BuildWithDependency(cacheDir string) error {
+	indexDir := filepath.Join(cacheDir, types.IndexesDir)
+	licenseDir := filepath.Join(cacheDir, types.LicenseDir)
+
+	licenseFile, err := os.Open(licenseDir + types.NormalizedlicenseFileName)
+	if err != nil {
+		xerrors.Errorf("failed to open normalized license file: %w", err)
+	}
+
+	licenseMap := make(map[string]string)
+
+	if err := json.NewDecoder(licenseFile).Decode(&licenseMap); err != nil {
+		return xerrors.Errorf("failed to decode license file: %w", err)
+	}
+
+	count, err := fileutil.Count(indexDir)
+	if err != nil {
+		return xerrors.Errorf("count error: %w", err)
+	}
+	bar := pb.StartNew(count)
+	defer log.Println("Build completed")
+	defer bar.Finish()
+
+	var indexes []types.Index
+	if err := fileutil.Walk(indexDir, func(r io.Reader, path string) error {
+		index := &crawler.Index{}
+		if err := json.NewDecoder(r).Decode(index); err != nil {
+			return xerrors.Errorf("failed to decode index: %w", err)
+		}
+		for _, ver := range index.Versions {
+			depList := make([]string, 0)
+			for _, v := range ver.Dependencies {
+				depList = append(depList, fmt.Sprintf("%s:%s:%s", v.GroupID, v.ArtifactID, v.Version))
+			}
+
+			indexes = append(indexes, types.Index{
+				GroupID:     index.GroupID,
+				ArtifactID:  index.ArtifactID,
+				Version:     ver.Version,
+				SHA1:        ver.SHA1,
+				ArchiveType: index.ArchiveType,
+				Dependency:  strings.Join(depList, ","),
+			})
+		}
+		bar.Increment()
+
+		if len(indexes) > 1000 {
+			if err = b.db.InsertIndexesWithJarDependencies(indexes); err != nil {
+				return xerrors.Errorf("failed to insert index to db: %w", err)
+			}
+			indexes = []types.Index{}
+		}
+		return nil
+	}); err != nil {
+		return xerrors.Errorf("walk error: %w", err)
+	}
+
+	// Insert the remaining indexes
+	if err = b.db.InsertIndexesWithJarDependencies(indexes); err != nil {
 		return xerrors.Errorf("failed to insert index to db: %w", err)
 	}
 

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -228,11 +228,16 @@ func (c *Crawler) crawlSHA1(baseURL string, meta *Metadata) error {
 			licenseKeys := lo.Uniq(pomValues.Licenses)
 			sort.Strings(licenseKeys)
 
+			dependencyList := make([]string, 0)
+			for _, v := range pomValues.Dependencies {
+				dependencyList = append(dependencyList, fmt.Sprintf("%s:%s:%s", v.GroupID, v.ArtifactID, v.Version))
+			}
+
 			v := Version{
-				Version:      version,
-				SHA1:         sha1,
-				License:      strings.Join(licenseKeys, "|"),
-				Dependencies: pomValues.Dependencies,
+				Version:    version,
+				SHA1:       sha1,
+				License:    strings.Join(licenseKeys, "|"),
+				Dependency: strings.Join(dependencyList, ","),
 			}
 
 			versions = append(versions, v)

--- a/pkg/crawler/crawler.go
+++ b/pkg/crawler/crawler.go
@@ -23,7 +23,6 @@ import (
 	"github.com/PuerkitoBio/goquery"
 	"github.com/hashicorp/go-retryablehttp"
 	cmap "github.com/orcaman/concurrent-map/v2"
-	"golang.org/x/net/html/charset"
 	"golang.org/x/sync/semaphore"
 	"golang.org/x/xerrors"
 )
@@ -222,17 +221,18 @@ func (c *Crawler) crawlSHA1(baseURL string, meta *Metadata) error {
 
 			// fetch license information on the basis of pom url
 			pomURL := getPomURL(baseURL, meta.ArtifactID, version)
-			licenseKeys, err := c.fetchAndSavePOMLicenseKeys(pomURL)
+			pomValues, err := c.parsePomForLicensesAndDeps(pomURL)
 			if err != nil {
 				log.Println(err)
 			}
-			licenseKeys = lo.Uniq(licenseKeys)
+			licenseKeys := lo.Uniq(pomValues.Licenses)
 			sort.Strings(licenseKeys)
 
 			v := Version{
-				Version: version,
-				SHA1:    sha1,
-				License: strings.Join(licenseKeys, "|"),
+				Version:      version,
+				SHA1:         sha1,
+				License:      strings.Join(licenseKeys, "|"),
+				Dependencies: pomValues.Dependencies,
 			}
 
 			versions = append(versions, v)
@@ -318,41 +318,29 @@ func (c *Crawler) fetchSHA1(url string) ([]byte, error) {
 	return sha1b, nil
 }
 
-func (c *Crawler) fetchAndSavePOMLicenseKeys(url string) ([]string, error) {
-	var keys []string
-	resp, err := c.http.Get(url)
-	if resp.StatusCode == http.StatusNotFound {
-		return keys, nil
-	}
+func (c *Crawler) parsePomForLicensesAndDeps(url string) (PomParsedValues, error) {
+	var pomParsedValues PomParsedValues
+	pomXml, err := parseAndSubstitutePom(url)
 	if err != nil {
-		return keys, xerrors.Errorf("can't get pom xml from %s: %w", url, err)
-	}
-	defer resp.Body.Close()
-
-	var pomProject PomProject
-
-	decoder := xml.NewDecoder(resp.Body)
-	decoder.CharsetReader = charset.NewReaderLabel
-	err = decoder.Decode(&pomProject)
-
-	if err != nil {
-		return keys, xerrors.Errorf("can't parse pom xml from %s: %w", url, err)
+		return pomParsedValues, xerrors.Errorf("can't parse pom xml from %s: %w", url, err)
 	}
 
-	if len(pomProject.Licenses) == 0 {
-		return keys, nil
+	if len(pomXml.Licenses) == 0 && len(pomXml.Dependencies) == 0 {
+		return pomParsedValues, nil
 	}
 
-	for _, l := range pomProject.Licenses {
+	for _, l := range pomXml.Licenses {
 		l.LicenseKey = getLicenseKey(l)
 
 		// update uniqueLicenseKeys map
 		c.uniqueLicenseKeys.Set(l.LicenseKey, l)
 
-		keys = append(keys, l.LicenseKey)
+		pomParsedValues.Licenses = append(pomParsedValues.Licenses, l.LicenseKey)
 	}
 
-	return keys, nil
+	pomParsedValues.Dependencies = pomXml.Dependencies
+
+	return pomParsedValues, nil
 
 }
 

--- a/pkg/crawler/pomutils.go
+++ b/pkg/crawler/pomutils.go
@@ -1,0 +1,125 @@
+package crawler
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"golang.org/x/net/html/charset"
+)
+
+type PomParsedValues struct {
+	Licenses     []string
+	Dependencies []Dependency
+}
+
+type PomProject struct {
+	GroupID      string       `xml:"groupId"`
+	ArtifactID   string       `xml:"artifactId"`
+	Version      string       `xml:"version"`
+	Name         string       `xml:"name"`
+	Description  string       `xml:"description"`
+	URL          string       `xml:"url"`
+	Licenses     []License    `xml:"licenses>license"`
+	Dependencies []Dependency `xml:"dependencies>dependency"`
+	Properties   Properties   `xml:"properties"`
+}
+
+type Properties struct {
+	Variables map[string]string `xml:",any"`
+}
+
+func (p *Properties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	p.Variables = make(map[string]string)
+	for {
+		var e xml.Token
+		e, err := d.Token()
+		if err != nil {
+			return err
+		}
+
+		switch elem := e.(type) {
+		case xml.StartElement:
+			key := strings.TrimPrefix(elem.Name.Local, "property.")
+			var value string
+			if err := d.DecodeElement(&value, &elem); err != nil {
+				return err
+			}
+			p.Variables[key] = value
+		case xml.EndElement:
+			if elem == start.End() {
+				return nil
+			}
+		}
+	}
+}
+
+func substitutePlaceholders(project *PomProject) {
+	for key, value := range project.Properties.Variables {
+		placeholder := "${" + key + "}"
+		// Substitute placeholders in dependencies
+		for i := range project.Dependencies {
+			project.Dependencies[i].GroupID = strings.ReplaceAll(project.Dependencies[i].GroupID, placeholder, value)
+			project.Dependencies[i].ArtifactID = strings.ReplaceAll(project.Dependencies[i].ArtifactID, placeholder, value)
+			project.Dependencies[i].Version = strings.ReplaceAll(project.Dependencies[i].Version, placeholder, value)
+		}
+	}
+}
+
+type License struct {
+	Name                     string `xml:"name"`
+	URL                      string `xml:"url"`
+	LicenseKey               string
+	ClassificationConfidence float64
+}
+
+type Dependency struct {
+	GroupID    string `xml:"groupId"`
+	ArtifactID string `xml:"artifactId"`
+	Version    string `xml:"version"`
+}
+
+func preprocessXML(xmlData string) (string, error) {
+	// Add closing tags to unclosed <hr> tags
+	xmlData = strings.ReplaceAll(xmlData, "<hr>", "")
+	xmlData = strings.ReplaceAll(xmlData, "</hr>", "")
+	return xmlData, nil
+}
+
+func parseAndSubstitutePom(url string) (PomProject, error) {
+	// url := "https://repo1.maven.org/maven2/ae/teletronics/solr/solr-plugins/0.3/solr-plugins-0.3.pom"
+	var project PomProject
+
+	resp, err := http.Get(url)
+	if err != nil {
+		fmt.Println("Error fetching POM file:", err)
+		return project, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println("Error reading response body:", err)
+		return project, err
+	}
+
+	xmlData, err := preprocessXML(string(body))
+	if err != nil {
+		fmt.Println("Error preprocessing XML:", err)
+		return project, err
+	}
+
+	decoder := xml.NewDecoder(strings.NewReader(xmlData))
+	decoder.CharsetReader = charset.NewReaderLabel
+	err = decoder.Decode(&project)
+	if err != nil {
+		fmt.Println("Error decoding POM file:", err)
+		return project, err
+	}
+
+	substitutePlaceholders(&project)
+
+	return project, nil
+}

--- a/pkg/crawler/pomutils.go
+++ b/pkg/crawler/pomutils.go
@@ -76,7 +76,7 @@ type Dependency struct {
 }
 
 func preprocessXML(xmlData string) (string, error) {
-	// Add closing tags to unclosed <hr> tags
+	// Remove all hr tags
 	xmlData = strings.ReplaceAll(xmlData, "<hr>", "")
 	xmlData = strings.ReplaceAll(xmlData, "</hr>", "")
 	return xmlData, nil

--- a/pkg/crawler/types.go
+++ b/pkg/crawler/types.go
@@ -22,8 +22,8 @@ type Index struct {
 	ArchiveType types.ArchiveType
 }
 type Version struct {
-	Version      string
-	SHA1         []byte
-	License      string
-	Dependencies []Dependency
+	Version    string
+	SHA1       []byte
+	License    string `json:",omitempty"`
+	Dependency string `json:",omitempty"`
 }

--- a/pkg/crawler/types.go
+++ b/pkg/crawler/types.go
@@ -22,24 +22,8 @@ type Index struct {
 	ArchiveType types.ArchiveType
 }
 type Version struct {
-	Version string
-	SHA1    []byte
-	License string
-}
-
-type PomProject struct {
-	GroupID     string    `xml:"groupId"`
-	ArtifactID  string    `xml:"artifactId"`
-	Version     string    `xml:"version"`
-	Name        string    `xml:"name"`
-	Description string    `xml:"description"`
-	URL         string    `xml:"url"`
-	Licenses    []License `xml:"licenses>license"`
-}
-
-type License struct {
-	Name                     string `xml:"name"`
-	URL                      string `xml:"url"`
-	LicenseKey               string
-	ClassificationConfidence float64
+	Version      string
+	SHA1         []byte
+	License      string
+	Dependencies []Dependency
 }

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	dbFileName    = "trivy-java.db"
-	SchemaVersion = 2 // Update schema version in case of schema changes
+	SchemaVersion = 3 // Update schema version in case of schema changes
 )
 
 type DB struct {

--- a/pkg/db/db_dependency.go
+++ b/pkg/db/db_dependency.go
@@ -10,10 +10,10 @@ import (
 )
 
 const (
-	dependencyDbFileName = "df-java-dependencies.db"
+	dependencyDbFileName = "df-java-dependency.db"
 )
 
-func NewDbWithDependencies(cacheDir string) (DB, error) {
+func NewDbWithDependency(cacheDir string) (DB, error) {
 	dbPath := filepath.Join(cacheDir, dependencyDbFileName)
 	dbDir := filepath.Dir(dbPath)
 	if err := os.MkdirAll(dbDir, 0700); err != nil {
@@ -37,7 +37,7 @@ func NewDbWithDependencies(cacheDir string) (DB, error) {
 	}, nil
 }
 
-func (db *DB) InitDbWithJarDependencies() error {
+func (db *DB) InitDbWithDependency() error {
 	if _, err := db.client.Exec("CREATE TABLE artifacts(id INTEGER PRIMARY KEY, group_id TEXT, artifact_id TEXT)"); err != nil {
 		return xerrors.Errorf("unable to create 'artifacts' table: %w", err)
 	}
@@ -56,7 +56,7 @@ func (db *DB) InitDbWithJarDependencies() error {
 	return nil
 }
 
-func (db *DB) InsertIndexesWithJarDependencies(indexes []types.Index) error {
+func (db *DB) InsertIndexesWithDependency(indexes []types.Index) error {
 	if len(indexes) == 0 {
 		return nil
 	}

--- a/pkg/db/db_dependency.go
+++ b/pkg/db/db_dependency.go
@@ -1,0 +1,88 @@
+package db
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+
+	"github.com/deepfactor-io/javadb/pkg/types"
+	"golang.org/x/xerrors"
+)
+
+const (
+	dependencyDbFileName = "df-java-dependencies.db"
+)
+
+func NewDbWithDependencies(cacheDir string) (DB, error) {
+	dbPath := filepath.Join(cacheDir, dependencyDbFileName)
+	dbDir := filepath.Dir(dbPath)
+	if err := os.MkdirAll(dbDir, 0700); err != nil {
+		return DB{}, xerrors.Errorf("failed to mkdir: %w", err)
+	}
+
+	// open db
+	var err error
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		return DB{}, xerrors.Errorf("can't open db: %w", err)
+	}
+
+	if _, err = db.Exec("PRAGMA foreign_keys=true"); err != nil {
+		return DB{}, xerrors.Errorf("failed to enable 'foreign_keys': %w", err)
+	}
+
+	return DB{
+		client: db,
+		dir:    dbDir,
+	}, nil
+}
+
+func (db *DB) InitDbWithJarDependencies() error {
+	if _, err := db.client.Exec("CREATE TABLE artifacts(id INTEGER PRIMARY KEY, group_id TEXT, artifact_id TEXT)"); err != nil {
+		return xerrors.Errorf("unable to create 'artifacts' table: %w", err)
+	}
+	if _, err := db.client.Exec("CREATE TABLE indices(artifact_id INTEGER, version TEXT, dependency TEXT, foreign key (artifact_id) references artifacts(id))"); err != nil {
+		return xerrors.Errorf("unable to create 'indices' table: %w", err)
+	}
+	if _, err := db.client.Exec("CREATE UNIQUE INDEX artifacts_idx ON artifacts(artifact_id, group_id)"); err != nil {
+		return xerrors.Errorf("unable to create 'artifacts_idx' index: %w", err)
+	}
+	if _, err := db.client.Exec("CREATE INDEX indices_artifact_idx ON indices(artifact_id)"); err != nil {
+		return xerrors.Errorf("unable to create 'indices_artifact_idx' index: %w", err)
+	}
+	if _, err := db.client.Exec("CREATE UNIQUE INDEX index_idx ON indices(artifact_id, version)"); err != nil {
+		return xerrors.Errorf("unable to create 'index_idx' index: %w", err)
+	}
+	return nil
+}
+
+func (db *DB) InsertIndexesWithJarDependencies(indexes []types.Index) error {
+	if len(indexes) == 0 {
+		return nil
+	}
+	tx, err := db.client.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if err = db.insertArtifacts(tx, indexes); err != nil {
+		return xerrors.Errorf("insert error: %w", err)
+	}
+
+	for _, index := range indexes {
+		_, err = tx.Exec(`
+			INSERT INTO indices(artifact_id, version, dependency)
+			VALUES (
+			        (SELECT id FROM artifacts
+			            WHERE group_id=? AND artifact_id=?),
+			        ?, ?
+			) ON CONFLICT(artifact_id, version) DO NOTHING`,
+			index.GroupID, index.ArtifactID, index.Version, index.Dependency)
+		if err != nil {
+			return xerrors.Errorf("unable to insert to 'indices' table: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}

--- a/pkg/db/db_dependency.go
+++ b/pkg/db/db_dependency.go
@@ -41,7 +41,7 @@ func (db *DB) InitDbWithJarDependencies() error {
 	if _, err := db.client.Exec("CREATE TABLE artifacts(id INTEGER PRIMARY KEY, group_id TEXT, artifact_id TEXT)"); err != nil {
 		return xerrors.Errorf("unable to create 'artifacts' table: %w", err)
 	}
-	if _, err := db.client.Exec("CREATE TABLE indices(artifact_id INTEGER, version TEXT, dependency TEXT, foreign key (artifact_id) references artifacts(id))"); err != nil {
+	if _, err := db.client.Exec("CREATE TABLE indices(artifact_id INTEGER, version TEXT, sha1 BLOB, dependency TEXT, foreign key (artifact_id) references artifacts(id))"); err != nil {
 		return xerrors.Errorf("unable to create 'indices' table: %w", err)
 	}
 	if _, err := db.client.Exec("CREATE UNIQUE INDEX artifacts_idx ON artifacts(artifact_id, group_id)"); err != nil {
@@ -50,8 +50,8 @@ func (db *DB) InitDbWithJarDependencies() error {
 	if _, err := db.client.Exec("CREATE INDEX indices_artifact_idx ON indices(artifact_id)"); err != nil {
 		return xerrors.Errorf("unable to create 'indices_artifact_idx' index: %w", err)
 	}
-	if _, err := db.client.Exec("CREATE UNIQUE INDEX index_idx ON indices(artifact_id, version)"); err != nil {
-		return xerrors.Errorf("unable to create 'index_idx' index: %w", err)
+	if _, err := db.client.Exec("CREATE UNIQUE INDEX indices_sha1_idx ON indices(sha1)"); err != nil {
+		return xerrors.Errorf("unable to create 'indices_sha1_idx' index: %w", err)
 	}
 	return nil
 }
@@ -72,13 +72,13 @@ func (db *DB) InsertIndexesWithJarDependencies(indexes []types.Index) error {
 
 	for _, index := range indexes {
 		_, err = tx.Exec(`
-			INSERT INTO indices(artifact_id, version, dependency)
+			INSERT INTO indices(artifact_id, version, sha1, dependency)
 			VALUES (
 			        (SELECT id FROM artifacts
 			            WHERE group_id=? AND artifact_id=?),
-			        ?, ?
-			) ON CONFLICT(artifact_id, version) DO NOTHING`,
-			index.GroupID, index.ArtifactID, index.Version, index.Dependency)
+			        ?, ?, ?
+			) ON CONFLICT(sha1) DO NOTHING`,
+			index.GroupID, index.ArtifactID, index.Version, index.SHA1, index.Dependency)
 		if err != nil {
 			return xerrors.Errorf("unable to insert to 'indices' table: %w", err)
 		}

--- a/pkg/db/db_dependency.go
+++ b/pkg/db/db_dependency.go
@@ -41,17 +41,14 @@ func (db *DB) InitDbWithDependency() error {
 	if _, err := db.client.Exec("CREATE TABLE artifacts(id INTEGER PRIMARY KEY, group_id TEXT, artifact_id TEXT)"); err != nil {
 		return xerrors.Errorf("unable to create 'artifacts' table: %w", err)
 	}
-	if _, err := db.client.Exec("CREATE TABLE indices(artifact_id INTEGER, version TEXT, sha1 BLOB, dependency TEXT, foreign key (artifact_id) references artifacts(id))"); err != nil {
+	if _, err := db.client.Exec("CREATE TABLE indices(artifact_id INTEGER, version TEXT, dependency TEXT, foreign key (artifact_id) references artifacts(id))"); err != nil {
 		return xerrors.Errorf("unable to create 'indices' table: %w", err)
 	}
 	if _, err := db.client.Exec("CREATE UNIQUE INDEX artifacts_idx ON artifacts(artifact_id, group_id)"); err != nil {
 		return xerrors.Errorf("unable to create 'artifacts_idx' index: %w", err)
 	}
-	if _, err := db.client.Exec("CREATE INDEX indices_artifact_idx ON indices(artifact_id)"); err != nil {
+	if _, err := db.client.Exec("CREATE INDEX indices_artifact_idx ON indices(artifact_id, version)"); err != nil {
 		return xerrors.Errorf("unable to create 'indices_artifact_idx' index: %w", err)
-	}
-	if _, err := db.client.Exec("CREATE UNIQUE INDEX indices_sha1_idx ON indices(sha1)"); err != nil {
-		return xerrors.Errorf("unable to create 'indices_sha1_idx' index: %w", err)
 	}
 	return nil
 }
@@ -72,13 +69,12 @@ func (db *DB) InsertIndexesWithDependency(indexes []types.Index) error {
 
 	for _, index := range indexes {
 		_, err = tx.Exec(`
-			INSERT INTO indices(artifact_id, version, sha1, dependency)
+			INSERT OR IGNORE INTO indices(artifact_id, version, dependency)
 			VALUES (
 			        (SELECT id FROM artifacts
-			            WHERE group_id=? AND artifact_id=?),
-			        ?, ?, ?
-			) ON CONFLICT(sha1) DO NOTHING`,
-			index.GroupID, index.ArtifactID, index.Version, index.SHA1, index.Dependency)
+			            WHERE group_id=? AND artifact_id=?), ?, ?
+			)`,
+			index.GroupID, index.ArtifactID, index.Version, index.Dependency)
 		if err != nil {
 			return xerrors.Errorf("unable to insert to 'indices' table: %w", err)
 		}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -19,4 +19,5 @@ type Index struct {
 	SHA1        []byte
 	ArchiveType ArchiveType
 	License     string
+	Dependency  string
 }


### PR DESCRIPTION
DB Package location: 
```
https://github.com/orgs/deepfactor-io/packages/container/package/javadependencydb
```
```
oras pull ghcr.io/deepfactor-io/javadependencydb:3
```

The following changes have been added to this PR
- Added a new build method `dependency-build` to create a Java db with dependencies
- The license and the archive_type columns have been removed. Note : I'm using the sha column for unique index
- Updated pomutils to parse and substitute variables in dependencies if any

Datapoints on the new db
- db size = ~~4 GB~~ 3.7 GB 
- compressed db size = ~~647.1 MB~~ 258 MB
- The following queries were run and the results are as follows
```
select COUNT()  from artifacts a
df-java-dependency.db has 430665 rows


select COUNT()  from indices i
df-java-dependency.db has 9355490 rows
```


NOTE : For testing purposes, I've kept the SchemaVersion as 3. The only change that has been 
added to the existing javadb is the way we parse the pom.xml. I think we should be using the 
same Schemaversion (2) while we merge this to 3.6 @namandf @john-d8r 

Will let @tejadf make changes to the cron.yaml
